### PR TITLE
Added check before flashing to reduce wear

### DIFF
--- a/wifi_manager/main/wifi_manager.c
+++ b/wifi_manager/main/wifi_manager.c
@@ -110,32 +110,83 @@ void wifi_manager_disconnect_async(){
 	xEventGroupSetBits(wifi_manager_event_group, WIFI_MANAGER_REQUEST_WIFI_DISCONNECT);
 }
 
+bool wifi_manager_flash_need_update(){
+	bool flash_is_different = false;
+	nvs_handle handle;
+	esp_err_t esp_err;
+	if(nvs_open(wifi_manager_nvs_namespace, NVS_READONLY, &handle) == ESP_OK){
+
+		if(wifi_manager_config_sta == NULL){
+			flash_is_different = true;
+		}
+
+		/* allocate buffer */
+		size_t sz = sizeof(wifi_settings);
+		uint8_t *buff = (uint8_t*)malloc(sizeof(uint8_t) * sz);
+		memset(buff, 0x00, sizeof(sz));
+
+		/* ssid */
+		sz = sizeof(wifi_manager_config_sta->sta.ssid);
+		esp_err = nvs_get_blob(handle, "ssid", buff, &sz);
+		if(esp_err != ESP_OK){
+			free(buff);
+			return true;
+		}
+		if(bcmp(&wifi_manager_config_sta->sta.ssid, buff, sz)) flash_is_different = true;
+
+		/* password */
+		sz = sizeof(wifi_manager_config_sta->sta.password);
+		esp_err = nvs_get_blob(handle, "password", buff, &sz);
+		if(esp_err != ESP_OK){
+			free(buff);
+			return true;
+		}
+		if(bcmp(&wifi_manager_config_sta->sta.password, buff, sz)) flash_is_different = true;
+
+		/* settings */
+		sz = sizeof(wifi_settings);
+		esp_err = nvs_get_blob(handle, "settings", buff, &sz);
+		if(esp_err != ESP_OK){
+			free(buff);
+			return true;
+		}
+		if(bcmp(&wifi_settings, buff, sz)) flash_is_different = true;
+
+		free(buff);
+		nvs_close(handle);
+		return flash_is_different;
+	}
+	else{
+		return true;
+	}
+}
 
 esp_err_t wifi_manager_save_sta_config(){
 
 	nvs_handle handle;
 	esp_err_t esp_err;
+	if(wifi_manager_flash_need_update()) {
 #if WIFI_MANAGER_DEBUG
 	printf("wifi_manager: About to save config to flash\n");
 #endif
-	if(wifi_manager_config_sta){
+		if(wifi_manager_config_sta){
 
-		esp_err = nvs_open(wifi_manager_nvs_namespace, NVS_READWRITE, &handle);
-		if (esp_err != ESP_OK) return esp_err;
+			esp_err = nvs_open(wifi_manager_nvs_namespace, NVS_READWRITE, &handle);
+			if (esp_err != ESP_OK) return esp_err;
 
-		esp_err = nvs_set_blob(handle, "ssid", wifi_manager_config_sta->sta.ssid, 32);
-		if (esp_err != ESP_OK) return esp_err;
+			esp_err = nvs_set_blob(handle, "ssid", wifi_manager_config_sta->sta.ssid, 32);
+			if (esp_err != ESP_OK) return esp_err;
 
-		esp_err = nvs_set_blob(handle, "password", wifi_manager_config_sta->sta.password, 64);
-		if (esp_err != ESP_OK) return esp_err;
+			esp_err = nvs_set_blob(handle, "password", wifi_manager_config_sta->sta.password, 64);
+			if (esp_err != ESP_OK) return esp_err;
 
-		esp_err = nvs_set_blob(handle, "settings", &wifi_settings, sizeof(wifi_settings));
-		if (esp_err != ESP_OK) return esp_err;
+			esp_err = nvs_set_blob(handle, "settings", &wifi_settings, sizeof(wifi_settings));
+			if (esp_err != ESP_OK) return esp_err;
 
-		esp_err = nvs_commit(handle);
-		if (esp_err != ESP_OK) return esp_err;
+			esp_err = nvs_commit(handle);
+			if (esp_err != ESP_OK) return esp_err;
 
-		nvs_close(handle);
+			nvs_close(handle);
 #if WIFI_MANAGER_DEBUG
 		printf("wifi_manager_wrote wifi_sta_config: ssid:%s password:%s\n",wifi_manager_config_sta->sta.ssid,wifi_manager_config_sta->sta.password);
 		printf("wifi_manager_wrote wifi_settings: SoftAP_ssid: %s\n",wifi_settings.ap_ssid);
@@ -150,8 +201,8 @@ esp_err_t wifi_manager_save_sta_config(){
 		printf("wifi_manager_wrote wifi_settings: sta_gw_addr: %s\n", ip4addr_ntoa(&wifi_settings.sta_static_ip_config.gw));
 		printf("wifi_manager_wrote wifi_settings: sta_netmask: %s\n", ip4addr_ntoa(&wifi_settings.sta_static_ip_config.netmask));
 #endif
+		}
 	}
-
 	return ESP_OK;
 }
 
@@ -212,7 +263,6 @@ bool wifi_manager_fetch_wifi_sta_config(){
 		printf("wifi_manager_fetch_wifi_settings: sta_only (0 = APSTA, 1 = STA when connected):%i\n",wifi_settings.sta_only);
 		printf("wifi_manager_fetch_wifi_settings: sta_power_save (1 = yes):%i\n",wifi_settings.sta_power_save);
 		printf("wifi_manager_fetch_wifi_settings: sta_static_ip (0 = dhcp client, 1 = static ip):%i\n",wifi_settings.sta_static_ip);
-		printf("wifi_manager_fetch_wifi_settings: sta_static_ip_config: IP: %s , GW: %s , Mask: %s\n", ip4addr_ntoa(&wifi_settings.sta_static_ip_config.ip), ip4addr_ntoa(&wifi_settings.sta_static_ip_config.gw), ip4addr_ntoa(&wifi_settings.sta_static_ip_config.netmask));
 		printf("wifi_manager_fetch_wifi_settings: sta_ip_addr: %s\n", ip4addr_ntoa(&wifi_settings.sta_static_ip_config.ip));
 		printf("wifi_manager_fetch_wifi_settings: sta_gw_addr: %s\n", ip4addr_ntoa(&wifi_settings.sta_static_ip_config.gw));
 		printf("wifi_manager_fetch_wifi_settings: sta_netmask: %s\n", ip4addr_ntoa(&wifi_settings.sta_static_ip_config.netmask));


### PR DESCRIPTION
Issue: When configuration has been saved to flash and esp32 reboot, it will read flash configuration and when it connects to the WiFi station it will save the configuration to flash again even though there have been no Changes.

Proposed solution: This commit add a check if the content of the flash is identical to the current configuration. In such case, it will skip Writing to the flash.

There are other ways of solving the issue, so it is up to you what to do.
