### PR TITLE
Configurable captive portal start

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -30,6 +30,13 @@ config WEBAPP_LOCATION
     help
     This parameter helps you relocate the wifimanager to another URL, for instance /wifimanager/ The trailing slash is important and should be included
 
+config CAPTIVE_PORTAL_LOCATION
+    string "Use this url for the captive portal"
+    default "/"
+    help
+    This is used when a different welcome screen is required. For example when a "welcome"-http handler is hooked in to
+    esp-wifi-manager. That handler should provide a link to get into the wifi setup.
+
 config DEFAULT_AP_SSID
     string "Access Point SSID"
     default "esp32"

--- a/src/http_app.c
+++ b/src/http_app.c
@@ -431,6 +431,7 @@ void http_app_start(bool lru_purge_enable){
 		/* generate the URLs */
 		if(http_root_url == NULL){
 			int root_len = strlen(WEBAPP_LOCATION);
+            int captive_portal_len = strlen(CAPTIVE_PORTAL_LOCATION);
 
 			/* all the pages */
 			const char page_js[] = "code.js";
@@ -450,12 +451,15 @@ void http_app_start(bool lru_purge_enable){
 			http_redirect_url = malloc(sizeof(char) * redirect_sz);
 			*http_redirect_url = '\0';
 
-			if(root_len == 1){
+            if(captive_portal_len > 1) {
+                snprintf(http_redirect_url, redirect_sz, "http://%s%s", DEFAULT_AP_IP, CAPTIVE_PORTAL_LOCATION);
+            } else if(root_len == 1){
 				snprintf(http_redirect_url, redirect_sz, "http://%s", DEFAULT_AP_IP);
-			}
-			else{
+			} else{
 				snprintf(http_redirect_url, redirect_sz, "http://%s%s", DEFAULT_AP_IP, WEBAPP_LOCATION);
 			}
+
+            ESP_LOGI(TAG, "Captive portal url: %s", http_redirect_url);
 
 			/* generate the other pages URLs*/
 			http_js_url = http_app_generate_url(page_js);

--- a/src/http_app.h
+++ b/src/http_app.h
@@ -47,6 +47,7 @@ extern "C" {
  *  you may want to relocate the wifi manager to another URL, for instance /wifimanager
  */
 #define WEBAPP_LOCATION 					CONFIG_WEBAPP_LOCATION
+#define CAPTIVE_PORTAL_LOCATION 		    CONFIG_CAPTIVE_PORTAL_LOCATION
 
 
 /** 

--- a/src/index.html
+++ b/src/index.html
@@ -34,14 +34,14 @@
 					<header>
 						<h1>Enter Details</h1>
 					</header>
-					<h2>Manual Connection</span></h2>
+					<h2>Manual Connection</h2>
 					<section>
-						<input id="manual_ssid" type="text" placeholder="SSID" value="">
-						<input id="manual_pwd" type="password" placeholder="Password" value="">
+						<input id="manual_ssid" type="text" placeholder="SSID" value="" />
+						<input id="manual_pwd" type="password" placeholder="Password" value="" />
 					</section>
 					<div class="buttons">
-							<input id="manual_join" type="button" value="Join" data-connect="manual" />
-							<input id="manual_cancel" type="button" value="Cancel"/>
+						<input id="manual_join" type="button" value="Join" data-connect="manual" />
+						<input id="manual_cancel" type="button" value="Cancel"/>
 					</div>
 				</div>
 				<div id="connect">
@@ -53,8 +53,8 @@
 						<input id="pwd" type="password" placeholder="Password" value="">
 					</section>
 					<div class="buttons">
-							<input id="join" type="button" value="Join" />
-							<input id="cancel" type="button" value="Cancel"/>
+						<input id="join" type="button" value="Join" />
+						<input id="cancel" type="button" value="Cancel"/>
 					</div>
 				</div>
 				<div id="connect-wait">

--- a/src/style.css
+++ b/src/style.css
@@ -100,7 +100,7 @@ h2 {
 h3 {
     margin: 0;
     text-align: center;
-    padding: 20px 0 20px 0;
+    padding: 20px 0;
 }
 .gr {
     color: green;

--- a/src/style.css
+++ b/src/style.css
@@ -66,7 +66,7 @@ p {
 }
 .ape {
     margin-left: 20px;
-    padding: 10px 0px 10px 10px;
+    padding: 10px 0 10px 10px;
 }
 .ape:hover {
     cursor: pointer;
@@ -91,8 +91,7 @@ h1 {
     font-size: 1.4em
 }
 h2 {
-    margin: 0;
-    margin-top: 20px;
+    margin: 20px 0 0;
     padding: 10px;
     text-transform: uppercase;
     color: #888;
@@ -101,7 +100,7 @@ h2 {
 h3 {
     margin: 0;
     text-align: center;
-    padding: 20px 0px 20px 0px;
+    padding: 20px 0 20px 0;
 }
 .gr {
     color: green;
@@ -122,21 +121,21 @@ h3 {
     border: none;
     width: 80%;
     margin-left: 35px;
-    padding: 10px 0px 10px 10px;
+    padding: 10px 0 10px 10px;
     display: block
 }
 #manual_pwd {
     border: none;
     width: 80%;
     margin-left: 35px;
-    padding: 10px 0px 10px 10px;
+    padding: 10px 0 10px 10px;
     display: block
 }
 #pwd {
     border: none;
     width: 80%;
     margin-left: 35px;
-    padding: 10px 0px 10px 10px;
+    padding: 10px 0 10px 10px;
     display: block
 }
 .buttons {


### PR DESCRIPTION
I added an extra configuration item to set the default redirect of the captive portal. Idea is that with a custom http hook (see examples), you can easily change the welcome screen of the captive portal. The creator of that welcome screen should then add a link on that welcome page, which redirects to the wifi configuration location.

This is mainly something I needed myself, but I thought that others might benefit from it as well.
My use case is to provide another form first, storing some details on the device. When that is ok, the link to configure wifi is shown.

Additionally I fixed some CSS/HTML stuff, because the linter in CLion highlighted it.
