### PR TITLE
Modified CMakeLists.txt, that project can be built directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,12 @@
 if(IDF_VERSION_MAJOR GREATER_EQUAL 4)
     idf_component_register(SRC_DIRS src
-        REQUIRES log nvs_flash mdns wpa_supplicant lwip esp_http_server
+        REQUIRES log nvs_flash mdns wpa_supplicant lwip esp_http_server esp_wifi
         INCLUDE_DIRS src
         EMBED_FILES src/style.css src/code.js src/index.html)
 else()
     set(COMPONENT_SRCDIRS src)
     set(COMPONENT_ADD_INCLUDEDIRS src)
-    set(COMPONENT_REQUIRES log nvs_flash mdns wpa_supplicant lwip esp_http_server)
+    set(COMPONENT_REQUIRES log nvs_flash mdns wpa_supplicant lwip esp_http_server esp_wifi)
     set(COMPONENT_EMBED_FILES src/style.css src/code.js src/index.html)
     register_component()
 endif()

--- a/src/wifi_manager.h
+++ b/src/wifi_manager.h
@@ -39,6 +39,7 @@ Contains the freeRTOS task and all necessary support
 extern "C" {
 #endif
 
+extern QueueHandle_t wifi_manager_queue;
 
 /**
  * @brief Defines the maximum size of a SSID name. 32 is IEEE standard.


### PR DESCRIPTION
**Using esp-idf version:** v5.3.0
**Chip:** ESP32S3
**OS:** Ubuntu 22.04

**Modified**: Add `esp_wifi `in CMakeLists.txt `set(COMPONENT_REQUIRES)`. Without it, the project can not be built directly.
